### PR TITLE
Fix/v2 driver

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ var rewire = require('rewire');
     Encoder = require('cassandra-driver/lib/encoder');
 
 var mockClient = rewire('cassandra-driver/lib/client');
+var cassandraPackage = require('cassandra-driver/package.json');
 
 exports.connectionCount = 0;
 exports.requestCount = 0;
@@ -13,9 +14,13 @@ mockClient.prototype.connect = function (callback) {
     this.connecting = false;
 
     this.metadata = this.controlConnection.metadata;
-    this.controlConnection.connection = {
-        encoder: new Encoder(null, this.controlConnection.options)
-    };
+
+    // Make compatible with v2
+    if (cassandraPackage.version.substr(0, 1) === '2') {    // TODO there's probably a better way to do this to check version
+        this.controlConnection.connection = {
+            encoder: new Encoder(null, this.controlConnection.options)
+        };
+    }
 
     // Collect stats
     exports.connectionCount++;

--- a/index.js
+++ b/index.js
@@ -41,6 +41,7 @@ mockRequestHandler.prototype.send = function (query, options, cb) {
 };
 
 mockRequestHandler.prototype.prepareMultiple = function (queries, callbacksArray, options, callback) {
+    // Collect prepare queries
     exports.requestCount += queries.length;
 
     callback();

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "rewire": "^2.1.3"
   },
   "devDependencies": {
-    "cassandra-driver": "^1.0.3",
+    "cassandra-driver": "^2.0.0",
     "mocha": "^2.0.1",
     "should": "^4.2.0"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cassandra-driver-mock",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "description": "Basic mocking of the cassandra-driver library.",
   "main": "index.js",
   "scripts": {

--- a/test/index.js
+++ b/test/index.js
@@ -20,7 +20,7 @@ describe('Mock', function() {
     });
 
     it('should one query and one new connection', function(done) {
-        cassandra.execute('SOME QUERY;', function(err, result) {
+        cassandra.execute('INSERT SOME QUERY;', function(err, result) {
             should.not.exist(err);
 
             cassandraMock.requestCount.should.equal(lastRequestCount + 1);
@@ -79,7 +79,7 @@ describe('Mock', function() {
         cassandra.batch(batchQuery, {prepare: true}, function(err, result) {
             should.not.exist(err);
 
-            cassandraMock.requestCount.should.equal(lastRequestCount + batchQuery.length);
+            cassandraMock.requestCount.should.equal(lastRequestCount + batchQuery.length + batchQuery.length); // prepare queries, then actual queries
             cassandraMock.connectionCount.should.equal(lastConnectionCount + 1);
 
             done();

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,7 @@
 var should = require('should');
 var cassandraMock = require('../index');
 var Cassandra = require('cassandra-driver').Client;
+var cassandraPackage = require('cassandra-driver/package.json');
 
 describe('Mock', function() {
     var cassandra;
@@ -79,7 +80,13 @@ describe('Mock', function() {
         cassandra.batch(batchQuery, {prepare: true}, function(err, result) {
             should.not.exist(err);
 
-            cassandraMock.requestCount.should.equal(lastRequestCount + batchQuery.length + batchQuery.length); // prepare queries, then actual queries
+            var prepareQueryCount = 0;  // v1 doesn't do prepare queries for batch
+
+            if (cassandraPackage.version.substr(0, 1) === '2') {
+                prepareQueryCount = batchQuery.length;
+            }
+
+            cassandraMock.requestCount.should.equal(lastRequestCount + prepareQueryCount + batchQuery.length); // prepare queries, then actual queries
             cassandraMock.connectionCount.should.equal(lastConnectionCount + 1);
 
             done();


### PR DESCRIPTION
Updated for v2.

Changes:
- Added missing objects for v2 (encoder and metadata)
- Added prepareBatch function stub on request handler and counts for it.
- Made compatible with v1

NOTE: Going to start making the versions match the driver.
